### PR TITLE
Rename the variable holding the data to be sorted

### DIFF
--- a/sorting/quicksort.pl
+++ b/sorting/quicksort.pl
@@ -6,28 +6,28 @@ use warnings;
 sub quicksort (\@) {qsort($_[0], 0, $#{$_[0]})}
 
 sub qsort{
-    my ($a, $p, $r) = @_;
+    my ($aref, $p, $r) = @_;
     
     if($p < $r){
-        my $q = partition($a, $p, $r);
-        qsort($a, $p, $q - 1);
-        qsort($a, $q + 1, $r);
+        my $q = partition($aref, $p, $r);
+        qsort($aref, $p, $q - 1);
+        qsort($aref, $q + 1, $r);
     }
 }
 
 sub partition{
-    my ($a, $p, $r) = @_;
-    my $x = $a->[$r];
+    my ($aref, $p, $r) = @_;
+    my $x = $aref->[$r];
     my $i = $p - 1;
     
     for my $j($p .. $r - 1){
-        if($a->[$j] <= $x){
+        if($aref->[$j] <= $x){
             $i++;
-            ($a->[$i], $a->[$j]) = ($a->[$j], $a->[$i]);
+            ($aref->[$i], $aref->[$j]) = ($aref->[$j], $aref->[$i]);
         }
     }
     
-    ($a->[$i + 1], $a->[$r]) = ($a->[$r], $a->[$i + 1]);
+    ($aref->[$i + 1], $aref->[$r]) = ($aref->[$r], $aref->[$i + 1]);
     return $i + 1;
 }
 


### PR DESCRIPTION
The variable $a is reserved in Perl for using in special cases of
sorting, thus the usage of it outside the sort() is discouraged (see
perldoc perlvar for details)